### PR TITLE
Terraform Version 0.11.11

### DIFF
--- a/terraform/terraform.nuspec
+++ b/terraform/terraform.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>terraform</id>
     <title>Terraform</title>
-    <version>0.11.10</version>
+    <version>0.11.11</version>
     <authors>Mitchell Hashimoto, HashiCorp</authors>
     <owners>James Toyer</owners>
     <summary>Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.</summary>
@@ -22,14 +22,20 @@ The key features of Terraform are:
 For more information, see the [introduction section](http://www.terraform.io/intro) of the Terraform website.
     </description>
     <releaseNotes>
-## 0.11.10 (October 23, 2018)
+## 0.11.11 (December 14, 2018)
+
+IMPROVEMENTS:
+
+* backend/remote: Return detailed version (in)compatibility information ([#19659](https://github.com/hashicorp/terraform/issues/19659))
+* core: Enhance service discovery error handling and messaging ([#19589](https://github.com/hashicorp/terraform/issues/19589))
+* core: Add support to retrieve version constraints to service discovery ([#19647](https://github.com/hashicorp/terraform/issues/19647))
 
 BUG FIXES:
 
-* backend/local: Do not use backend operation variables ([#19175](https://github.com/hashicorp/terraform/issues/19175))
+* backend/remote: Fix symlink issues and Windows support when uploading configurations ([#19573](https://github.com/hashicorp/terraform/issues/19573))
 
 ## Previous Releases
-For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v0.11.10/CHANGELOG.md).</releaseNotes>
+For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v0.11.11/CHANGELOG.md).</releaseNotes>
     <projectUrl>http://www.terraform.io</projectUrl>
     <docsUrl>https://www.terraform.io/docs/index.html</docsUrl>
     <bugTrackerUrl>https://github.com/hashicorp/terraform/issues</bugTrackerUrl>

--- a/terraform/tools/chocolateyInstall.ps1
+++ b/terraform/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 # DO NOT CHANGE THESE MANUALLY. USE update.ps1
-$url        = 'https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_windows_386.zip'
-$url64      = 'https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_windows_amd64.zip'
-$checksum   = 'e832fe40647cdeea6eebed8abfaf0c775fcd951d1b030844597ad1eaf5d6b205'
-$checksum64 = '7bbb3d631fa0050431cc73e7fc9892ef60128d838ed8b4afc1a36f1398c717a2'
+$url        = 'https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_windows_386.zip'
+$url64      = 'https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_windows_amd64.zip'
+$checksum   = 'f97dbb8a43081b67bc3d7176115adee0a578d724a6b0885c506f62ad39c9b2b0'
+$checksum64 = '87252cc67486ef2ff2b8501c0bf9e795a53585b4dc5c09a8aa876c2564f77991'
 
 $unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
 


### PR DESCRIPTION
With the creation of automated package creation from #117, I've got ahead and run it for the first time for Terraform 0.11.11. This means #116 is obsolete. 

A future PR will work on trying to automate the creation and pushing of packages to ensure most of the manual process has been removed