### PR TITLE
Update to Terraform 0.12.23

### DIFF
--- a/terraform/terraform.nuspec
+++ b/terraform/terraform.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>terraform</id>
     <title>Terraform</title>
-    <version>0.12.20</version>
+    <version>0.12.23</version>
     <authors>Mitchell Hashimoto, HashiCorp</authors>
     <owners>James Toyer</owners>
     <summary>Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.</summary>
@@ -22,27 +22,9 @@ The key features of Terraform are:
 For more information, see the [introduction section](http://www.terraform.io/intro) of the Terraform website.
     </description>
     <releaseNotes>
-## 0.12.20 (January 22, 2020)
-
-ENHANCEMENTS:
-* config: New built-in functions `try` and `can` are intended to ease working with data structures whose shape isn't known statically. ([#23794](https://github.com/hashicorp/terraform/issues/23794))
-* config: New, optional syntax for [`required_providers`](https://www.terraform.io/docs/configuration/terraform.html#specifying-required-provider-versions) setting in `terraform` blocks. This is not intended for general use yet but will support upcoming enhancements. [[#23843](https://github.com/hashicorp/terraform/issues/23843)] 
-
-BUG FIXES:
-* command/show: Fix an issue with show and aliased providers ([#23848](https://github.com/hashicorp/terraform/issues/23848))
-* core: Always clean up empty resources before empty modules ([#23822](https://github.com/hashicorp/terraform/issues/23822))
-* internal/modsdir/manifest: Fix CLI issue with Windows machines ([#23865](https://github.com/hashicorp/terraform/issues/23865))
-
-EXPERIMENTS:
-
-* This release includes an _opt-in experiment_ for [custom validation rules on module variables](https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules).
-
-    The feature is not yet finalized and is subject to breaking changes even in minor releases, but we're introducing it here in order to solicit feedback from module developers about which use-cases it is meeting, any use-cases it _isn't_ meeting, and any situations where things feel harder to express than they might be.
-
-    Due to the experimental nature of this feature, we do not recommend using it in "production" modules yet and we require an explicit [experimental feature opt-in](https://www.terraform.io/docs/configuration/terraform.html#experimental-language-features) of `variable_validation`. Depending on what feedback we receive, the design of this experimental feature may change significantly in future versions without an automatic upgrade path.
-
+## 0.12.23 (March 05, 2020)
 ## Previous Releases
-For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v0.12.20/CHANGELOG.md).</releaseNotes>
+For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v0.12.23/CHANGELOG.md).</releaseNotes>
     <projectUrl>http://www.terraform.io</projectUrl>
     <docsUrl>https://www.terraform.io/docs/index.html</docsUrl>
     <bugTrackerUrl>https://github.com/hashicorp/terraform/issues</bugTrackerUrl>

--- a/terraform/tools/chocolateyInstall.ps1
+++ b/terraform/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 # DO NOT CHANGE THESE MANUALLY. USE update.ps1
-$url        = 'https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_windows_386.zip'
-$url64      = 'https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_windows_amd64.zip'
-$checksum   = '3e7c6aca476f7c82a96106d854f72851715483939667d99ebb0118a944592b6b'
-$checksum64 = '7213442bb7b7b554ec0895a2917a71e0e2945ffbae5424bb92696d9213f50bb6'
+$url        = 'https://releases.hashicorp.com/terraform/0.12.23/terraform_0.12.23_windows_386.zip'
+$url64      = 'https://releases.hashicorp.com/terraform/0.12.23/terraform_0.12.23_windows_amd64.zip'
+$checksum   = '6c9484b7839268620f15ee1694a86cc9067a3e4b6bcf9dc0eb80056cd575aab2'
+$checksum64 = '79f89c2622a3ec656f13e92326d1ad98893659eada8f556957e8e0f2e4d688d2'
 
 $unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
 


### PR DESCRIPTION
Updated to Terraform 0.12.23 using `update.ps1`:

- [X] Download Links Working
  - [X] 32-bit
  - [X] 64-bit
- [X] Hash match
  - [X] 32-bit
  - [X] 64-bit
- [X] Local Validation

```
# choco install terraform -version 0.12.23 -dv -s .
Chocolatey installed 1/1 packages.
# terraform --version
Terraform v0.12.23
```