### PR TITLE
Update to Terraform 0.12.26

### DIFF
--- a/terraform/terraform.nuspec
+++ b/terraform/terraform.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>terraform</id>
     <title>Terraform</title>
-    <version>0.12.25</version>
+    <version>0.12.26</version>
     <authors>Mitchell Hashimoto, HashiCorp</authors>
     <owners>James Toyer</owners>
     <summary>Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.</summary>
@@ -22,23 +22,15 @@ The key features of Terraform are:
 For more information, see the [introduction section](http://www.terraform.io/intro) of the Terraform website.
     </description>
     <releaseNotes>
-## 0.12.25 (May 13, 2020)
-
-NOTES:
-
-* backend/s3: Region validation now automatically supports the new `af-south-1` (Africa (Cape Town)) region. For AWS operations to work in the new region, the region must be explicitly enabled as outlined in the [AWS Documentation](https://docs.aws.amazon.com/general/latest/gr/rande-manage.html#rande-manage-enable). When the region is not enabled, the Terraform S3 Backend will return errors during credential validation (e.g. `error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid`). ([#24744](https://github.com/hashicorp/terraform/issues/24744))
+## 0.12.26 (May 27, 2020)
 
 ENHANCEMENTS:
 
-* backend/s3: Support automatic region validation for `af-south-1` ([#24744](https://github.com/hashicorp/terraform/issues/24744))
-* backend/remote: Add support for force push to remote backend ([#24884](https://github.com/hashicorp/terraform/issues/24884))
-
-BUG FIXES:
-* core: Destroy provisioners should not evaluate for_each expressions ([#24163](https://github.com/hashicorp/terraform/issues/24163))
-* core: Fix races in GetVariableValue ([#24599](https://github.com/hashicorp/terraform/issues/24599))
+* backend/remote: Can now accept `-target` options when creating a plan using _remote operations_, if supported by the target server. (Server-side support for this in Terraform Cloud and Terraform Enterprise will follow in forthcoming releases of each.) ([#24834](https://github.com/hashicorp/terraform/issues/24834))
+* cli: A special new lifecycle mode for provider plugins where they are assumed to be controlled by an external process outside of Terraform. This is for automated provider plugin testing only, and is not an end-user feature. ([#24674](https://github.com/hashicorp/terraform/issues/24674))
 
 ## Previous Releases
-For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v0.12.25/CHANGELOG.md).</releaseNotes>
+For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v0.12.26/CHANGELOG.md).</releaseNotes>
     <projectUrl>http://www.terraform.io</projectUrl>
     <docsUrl>https://www.terraform.io/docs/index.html</docsUrl>
     <bugTrackerUrl>https://github.com/hashicorp/terraform/issues</bugTrackerUrl>

--- a/terraform/tools/chocolateyInstall.ps1
+++ b/terraform/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 # DO NOT CHANGE THESE MANUALLY. USE update.ps1
-$url        = 'https://releases.hashicorp.com/terraform/0.12.25/terraform_0.12.25_windows_386.zip'
-$url64      = 'https://releases.hashicorp.com/terraform/0.12.25/terraform_0.12.25_windows_amd64.zip'
-$checksum   = 'daa4d3ce5e3e0dbcfe83be4310e7c8fb50098953e2e8fbfabfe2bc526390bcca'
-$checksum64 = '81356460648abc8e6b76974c518be7989c6fd6f497bb3c604988fd876b363321'
+$url        = 'https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_windows_386.zip'
+$url64      = 'https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_windows_amd64.zip'
+$checksum   = 'a793b82a0b61e87a4174aff54efcfdf522a2a20b21d73875e9581156f9ae036a'
+$checksum64 = 'f232bf25dc32e618fbb692b98857d10a84e16e531e9ce5e87e060c1369bde092'
 
 $unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
 


### PR DESCRIPTION
Updated to Terraform 0.12.26 using `update.ps1`:

- [X] Download Links Working
  - [X] 32-bit
  - [X] 64-bit
- [X] Hash match
  - [X] 32-bit
  - [X] 64-bit
- [X] Local Validation

```
# choco install terraform -version 0.12.26 -dv -s .
Chocolatey installed 1/1 packages.
# terraform --version
Terraform v0.12.26
```