### PR TITLE
terraform 1.6.5 and terraform automated release

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,15 @@
+- match:
+    dependency_name: terraform
+    update_type: semver:minor
+
+#- match:
+#    dependency_type: development
+#    update_type: semver:minor # includes patch updates!
+#
+#- match:
+#    dependency_type: production
+#    update_type: security:minor # includes patch updates!
+#
+#- match:
+#    dependency_type: production
+#    update_type: semver:patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+  
+  - package-ecosystem: "terraform"
+    directory: "/dummy_terraform"
+    schedule:
+      interval: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,236 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "addLabels": ["renovate"],
+    "allowPlugins": true,
+    "assignAutomerge": true,
+    "assignees": [],
+    "assigneesFromCodeOwners": true,
+    "assigneesSampleSize": 2,
+    "autoApprove": true,
+    "autodiscover": true,
+    "automerge": true,
+    "automergeComment": "automergeComment",
+    "automergeSchedule": ["at any time"],
+    "automergeStrategy": "rebase",
+    "automergeType": "pr",
+    "azure-pipelines": {
+      "enabled": true,
+      "fileMatch": ["\\.ya?ml$"]
+    },
+    "azureWorkItemId": 0,
+    "bicep": {
+      "fileMatch": ["\\.bicep$"]
+    },
+    "cloneSubmodules": true,
+    "configMigration": true,
+    "configWarningReuseIssue": false,
+    "dependencyDashboard": true,
+    "dependencyDashboardAutoclose": true,
+    "description": "standard CAG config",
+    "dockerfile": {
+      "fileMatch": [
+        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
+        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$"
+      ]
+    },
+    "enabled": true,
+    "exposeAllEnv": false,
+    "extends": ["config:base"],
+    "fetchReleaseNotes": "pr",
+    "git-submodules": {
+      "enabled": false,
+      "fileMatch": ["(^|/)\\.gitmodules$"],
+      "versioning": "git"
+    },
+    "gitAuthor": "renovate@ca-grp.com",
+    "github-actions": {
+      "fileMatch": [
+        "^(workflow-templates|\\.(?:github|gitea|forgejo)/workflows)/[^/]+\\.ya?ml$",
+        "(^|/)action\\.ya?ml$"
+      ]
+    },
+    "githubTokenWarn": true,
+    "gomod": {
+      "fileMatch": ["(^|/)go\\.mod$"],
+      "pinDigests": false
+    },
+    "group": {
+      "branchTopic": "{{{groupSlug}}}",
+      "commitMessageTopic": "{{{groupName}}}"
+    },
+    "helm-requirements": {
+      "commitMessageTopic": "helm chart {{depName}}",
+      "fileMatch": ["(^|/)requirements\\.ya?ml$"],
+      "registryAliases": {
+        "stable": "https://charts.helm.sh/stable"
+      }
+    },
+    "helm-values": {
+      "commitMessageTopic": "helm values {{depName}}",
+      "fileMatch": ["(^|/)values\\.ya?ml$"],
+      "pinDigests": false
+    },
+    "helmfile": {
+      "commitMessageTopic": "helm chart {{depName}}",
+      "fileMatch": ["(^|/)helmfile\\.ya?ml$"],
+      "registryAliases": {
+        "stable": "https://charts.helm.sh/stable"
+      }
+    },
+    "helmv3": {
+      "commitMessageTopic": "helm chart {{depName}}",
+      "fileMatch": ["(^|/)Chart\\.ya?ml$"],
+      "registryAliases": {
+        "stable": "https://charts.helm.sh/stable"
+      }
+    },
+    "homebrew": {
+      "commitMessageTopic": "Homebrew Formula {{depName}}",
+      "fileMatch": ["^Formula/[^/]+[.]rb$"]
+    },
+    "html": {
+      "digest": {
+        "enabled": false
+      },
+      "fileMatch": ["\\.html?$"],
+      "pinDigests": false,
+      "versioning": "semver"
+    },
+    "ignoreDeprecated": true,
+    "ignoreScripts": false,
+    "ignoreUnstable": true,
+    "kotlin-script": {
+      "fileMatch": ["^.+\\.main\\.kts$"]
+    },
+    "kubernetes": {
+      "fileMatch": []
+    },
+    "kustomize": {
+      "fileMatch": ["(^|/)kustomization\\.ya?ml$"],
+      "pinDigests": false
+    },
+    "labels": [],
+    "logFile": "",
+    "logFileLevel": "debug",
+    "major": {
+      "autoApprove": false,
+      "autodiscover": true,
+      "automerge": false,
+      "automergeComment": "Automatically update minor version",
+      "automergeSchedule": ["at any time"],
+      "automergeStrategy": "rebase",
+      "automergeType": "pr",
+      "description": "DO NOT automatically update and approve major versions"
+    },
+    "maven": {
+      "fileMatch": [
+        "(^|/|\\.)pom\\.xml$",
+        "^(((\\.mvn)|(\\.m2))/)?settings\\.xml$"
+      ],
+      "versioning": "maven"
+    },
+    "maven-wrapper": {
+      "fileMatch": ["(^|\\/).mvn/wrapper/maven-wrapper.properties$"],
+      "versioning": "maven"
+    },
+    "minor": {
+      "autoApprove": true,
+      "autodiscover": true,
+      "automerge": true,
+      "automergeComment": "Automatically update minor version",
+      "automergeSchedule": ["at any time"],
+      "automergeStrategy": "rebase",
+      "automergeType": "pr",
+      "description": "Automatically update and approve minor versions"
+    },
+    "nodenv": {
+      "fileMatch": ["(^|/)\\.node-version$"],
+      "versioning": "node"
+    },
+    "npm": {
+      "digest": {
+        "prBodyDefinitions": {
+          "Change": "{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+        }
+      },
+      "fileMatch": ["(^|/)package\\.json$"],
+      "prBodyDefinitions": {
+        "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+      },
+      "versioning": "npm"
+    },
+    "npmrcMerge": true,
+    "nuget": {
+      "fileMatch": [
+        "\\.(?:cs|fs|vb)proj$",
+        "\\.(?:props|targets)$",
+        "(^|/)dotnet-tools\\.json$",
+        "(^|/)global\\.json$"
+      ]
+    },
+    "onboarding": true,
+    "onboardingConfig": {
+      "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+    },
+    "onboardingConfigFileName": ".github/renovate.json",
+    "patch": {
+      "autoApprove": true,
+      "autodiscover": true,
+      "automerge": true,
+      "automergeComment": "Automatically update minor version",
+      "automergeSchedule": ["at any time"],
+      "automergeStrategy": "rebase",
+      "automergeType": "pr",
+      "description": "Automatically update and approve patch versions"
+    },
+    "pin": {
+      "commitMessageAction": "Pin",
+      "group": {
+        "commitMessageExtra": "",
+        "commitMessageTopic": "dependencies"
+      },
+      "groupName": "Pin Dependencies",
+      "groupSlug": "pin-dependencies",
+      "rebaseWhen": "behind-base-branch"
+    },
+    "prConcurrentLimit": 10,
+    "prCreation": "immediate",
+    "pre-commit": {
+      "commitMessageTopic": "pre-commit hook {{depName}}",
+      "enabled": false,
+      "fileMatch": ["(^|/)\\.pre-commit-config\\.ya?ml$"],
+      "prBodyNotes": [
+        "Note: The `pre-commit` manager in Renovate is not supported by the `pre-commit` maintainers or community. Please do not report any problems there, instead [create a Discussion in the Renovate repository](https://github.com/renovatebot/renovate/discussions/new) if you have any questions."
+      ]
+    },
+    "pruneBranchAfterAutomerge": true,
+    "rebaseWhen": "auto",
+    "recreateWhen": "auto",
+    "schedule": ["at any time"],
+    "semanticCommits": "auto",
+    "semanticCommitScope": "deps",
+    "semanticCommitType": "chore",
+    "separateMajorMinor": true,
+    "separateMinorPatch": false,
+    "separateMultipleMajor": true,
+    "terraform": {
+      "commitMessageTopic": "Terraform {{depName}}",
+      "fileMatch": ["\\.tf$"],
+      "pinDigests": false
+    },
+    "terraform-version": {
+      "extractVersion": "^v(?<version>.*)$",
+      "fileMatch": ["(^|/)\\.terraform-version$"],
+      "versioning": "hashicorp"
+    },
+    "tflint-plugin": {
+      "commitMessageTopic": "TFLint plugin {{depName}}",
+      "extractVersion": "^v(?<version>.*)$",
+      "fileMatch": ["\\.tflint\\.hcl$"]
+    },
+    "timezone": "GB",
+    "unicodeEmoji": true,
+    "updatePinnedDependencies": true,
+    "useBaseBranchConfig": "merge"
+  }
+  

--- a/.github/workflows/autoupdate_terraform.yml
+++ b/.github/workflows/autoupdate_terraform.yml
@@ -1,0 +1,29 @@
+name: Automatically update terraform.nuspec
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+permissions:
+  contents: write
+  pull-requests: write
+on: create
+
+jobs:
+    job1:
+      name: "auto-update"
+      runs-on: ubuntu-latest
+      if: ${{ startsWith(github.ref, 'refs/heads/dependabot/') }}
+      steps:
+        - uses: actions/checkout@v4
+        - name: Build Module
+          shell: pwsh
+          run: ./terraform/update.ps1
+
+        - name: Configure git
+          run: |
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+        
+        - name: Commit changes to terraform.nuspec
+          run: |
+              git add terraform.nuspec
+              git commit -m "[dependabot skip] Update terraform.nuspec"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,21 +1,41 @@
 # This is a basic workflow to help you get started with Actions
 
 name: Build
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   pull_request:
     branches:
       - develop
+  
 
   workflow_dispatch:
 
 jobs:
+  auto-merge:
+    name: "auto-merge"
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: "${{ secrets.PAT }}"
+          config: .github/auto-merge.yml
+          target: minor
+
   terraform:
     runs-on: windows-latest
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+
+      - name: Build Module
+        shell: pwsh
+        run: ./terraform/update.ps1
 
       - name: Choco pack
         uses: crazy-max/ghaction-chocolatey@v3.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - develop
-  
 
   workflow_dispatch:
 
@@ -32,10 +31,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
-
-      - name: Build Module
-        shell: pwsh
-        run: ./terraform/update.ps1
 
       - name: Choco pack
         uses: crazy-max/ghaction-chocolatey@v3.0.0

--- a/dummy_terraform/versions.tf
+++ b/dummy_terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform{
+required_version ="1.6.5"
+}

--- a/terraform/terraform.nuspec
+++ b/terraform/terraform.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>terraform</id>
     <title>Terraform</title>
-    <version>1.6.4</version>
+    <version>1.6.5</version>
     <authors>Mitchell Hashimoto, HashiCorp</authors>
     <owners>James Toyer</owners>
     <summary>Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.</summary>
@@ -22,17 +22,15 @@ The key features of Terraform are:
 For more information, see the [introduction section](http://www.terraform.io/intro) of the Terraform website.
     </description>
     <releaseNotes>
-## 1.6.4 (November 15, 2023)
-
-ENHANCEMENTS:
-* backend/s3: Add the parameter `endpoints.sso` to allow overriding the AWS SSO API endpoint. ([#34195](https://github.com/hashicorp/terraform/pull/34195))
+## 1.6.5 (November 29, 2023)
 
 BUG FIXES:
-* `terraform test`: Fix bug preventing passing sensitive output values from previous run blocks as inputs to future run blocks. ([#34190](https://github.com/hashicorp/terraform/pull/34190))
-* backend/s3: Add `https_proxy` and `no_proxy` parameters to allow fully specifying proxy configuration ([#34243](https://github.com/hashicorp/terraform/pull/34243))
+* backend/s3: Fixes parsing errors in shared config and credentials files. ([#34313](https://github.com/hashicorp/terraform/pull/34313))
+* backend/s3: Fixes error with AWS SSO when using FIPS endpoints. ([#34313](https://github.com/hashicorp/terraform/pull/34313))
+
 
 ## Previous Releases
-For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v1.6.4/CHANGELOG.md).</releaseNotes>
+For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v1.6.5/CHANGELOG.md).</releaseNotes>
     <projectUrl>http://www.terraform.io</projectUrl>
     <docsUrl>https://www.terraform.io/docs/index.html</docsUrl>
     <bugTrackerUrl>https://github.com/hashicorp/terraform/issues</bugTrackerUrl>

--- a/terraform/tools/chocolateyInstall.ps1
+++ b/terraform/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 # DO NOT CHANGE THESE MANUALLY. USE update.ps1
-$url = 'https://releases.hashicorp.com/terraform/1.6.4/terraform_1.6.4_windows_386.zip'
-$url64 = 'https://releases.hashicorp.com/terraform/1.6.4/terraform_1.6.4_windows_amd64.zip'
-$checksum = 'ab55f4cac284bc014976e4d8f7db3959f867ece25ec04239f017d6c4f7d2adba'
-$checksum64 = 'eb377e261497a9de1f5c19a711f9b1918bd2755699cb5cb49408493637664250'
+$url = 'https://releases.hashicorp.com/terraform/1.6.5/terraform_1.6.5_windows_386.zip'
+$url64 = 'https://releases.hashicorp.com/terraform/1.6.5/terraform_1.6.5_windows_amd64.zip'
+$checksum = 'f19e749bff7c5a44c07aa8ec7efe8e3986105691b92df93f62de22efb523a983'
+$checksum64 = '5c4644f8c83f3851b70e3c3a52c68e36949b1f8436617577a69af162b4a3c815'
 
 $unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
 


### PR DESCRIPTION
1. Updated terraform to 1.6.5
2. aded dummy_terraform folder with versions.tf
3. updated dependabot config to include terraform for dummy_terraform dir
4. added renovate config for alternative option
5. modified build.yml 
   1. to run auto merge of terraform dependencies of minor versions (includes patches) from dependabot
6. created additional auto-update workflow to 
    1. run update ps1 script and check in the results onto the dependabot branch