### PR TITLE
Enable auto-maintaining

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,15 @@
+- match:
+    dependency_name: terraform
+    update_type: semver:minor
+
+#- match:
+#    dependency_type: development
+#    update_type: semver:minor # includes patch updates!
+#
+#- match:
+#    dependency_type: production
+#    update_type: security:minor # includes patch updates!
+#
+#- match:
+#    dependency_type: production
+#    update_type: semver:patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,12 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+      time: "00:00"
+      timezone: "Europe/London"
   
   - package-ecosystem: "terraform"
-    directory: "/dummy_terraform"
+    directory: "/dummy_terraform/"
     schedule:
       interval: "daily"
+      time: "00:00"
+      timezone: "Europe/London"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+  
+  - package-ecosystem: "terraform"
+    directory: "/dummy_terraform"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/autoupdate_terraform.yml
+++ b/.github/workflows/autoupdate_terraform.yml
@@ -1,0 +1,29 @@
+name: Automatically update terraform.nuspec
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+permissions:
+  contents: write
+  pull-requests: write
+on: create
+
+jobs:
+    job1:
+      name: "auto-update"
+      runs-on: ubuntu-latest
+      if: ${{ startsWith(github.ref, 'refs/heads/dependabot/') }}
+      steps:
+        - uses: actions/checkout@v4
+        - name: Build Module
+          shell: pwsh
+          run: ./terraform/update.ps1
+
+        - name: Configure git
+          run: |
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+        
+        - name: Commit changes to terraform.nuspec
+          run: |
+              git add terraform.nuspec
+              git commit -m "[dependabot skip] Update terraform.nuspec"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
-# This is a basic workflow to help you get started with Actions
+ # This is a basic workflow to help you get started with Actions
 
 name: Build
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   pull_request:
@@ -10,6 +13,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  auto-merge:
+    name: "auto-merge"
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: "${{ secrets.PAT }}"
+          config: .github/auto-merge.yml
+          target: minor
+
   terraform:
     runs-on: windows-latest
 

--- a/dummy_terraform/versions.tf
+++ b/dummy_terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform{
+required_version ="1.6.5"
+} 


### PR DESCRIPTION
# enable auto maintenance
This PR adds a dummy terraform version.tf which dependabot interrogates and creates pull requests to update when a new version becomes available. These branches then have the auto update powershell script ran inside of them, and the results are committed onto the dependabot branch. 

Once this has happened the, the build workflow kicks in and auto merges the dependabot branch