### PR TITLE
Terraform 1.7.4

### DIFF
--- a/terraform/terraform.nuspec
+++ b/terraform/terraform.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>terraform</id>
     <title>Terraform</title>
-    <version>1.7.3</version>
+    <version>1.7.4</version>
     <authors>Mitchell Hashimoto, HashiCorp</authors>
     <owners>James Toyer</owners>
     <summary>Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.</summary>
@@ -22,16 +22,15 @@ The key features of Terraform are:
 For more information, see the [introduction section](http://www.terraform.io/intro) of the Terraform website.
     </description>
     <releaseNotes>
-## 1.7.3 (February 7, 2024)
+## 1.7.4 (February 21, 2024)
 
-BUG FIXES: 
+BUG FIXES:
 
-* `terraform test`: Fix crash when dynamic-typed attributes are not assigned values in mocks. ([#34610](https://github.com/hashicorp/terraform/pull/34511))
-* provisioners/file: Fix panic when source is null. ([#34621](https://github.com/hashicorp/terraform/pull/34621))
-* `import`: Throw helpful error message if an import block is configured with an empty ID ([34625](https://github.com/hashicorp/terraform/pull/34625))
+* `terraform test`: Fix automatic loading of variable files within the test directory on `windows` platforms. ([#34666](https://github.com/hashicorp/terraform/pull/34666))
+* plan renderer: Very large numbers (&gt; 2^63) will no longer be truncated in the human-readable plan. ([#34702](https://github.com/hashicorp/terraform/pull/34702))
 
 ## Previous Releases
-For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v1.7.3/CHANGELOG.md).</releaseNotes>
+For more information on previous releases, check out the changelog on [GitHub](https://github.com/hashicorp/terraform/blob/v1.7.4/CHANGELOG.md).</releaseNotes>
     <projectUrl>http://www.terraform.io</projectUrl>
     <docsUrl>https://www.terraform.io/docs/index.html</docsUrl>
     <bugTrackerUrl>https://github.com/hashicorp/terraform/issues</bugTrackerUrl>

--- a/terraform/tools/chocolateyInstall.ps1
+++ b/terraform/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 # DO NOT CHANGE THESE MANUALLY. USE update.ps1
-$url = 'https://releases.hashicorp.com/terraform/1.7.3/terraform_1.7.3_windows_386.zip'
-$url64 = 'https://releases.hashicorp.com/terraform/1.7.3/terraform_1.7.3_windows_amd64.zip'
-$checksum = '8bd44d5ae10d0f909d30c7bbe86b3a00f11177346f36536df0bab91fc93d7296'
-$checksum64 = '739ef5e564fd8128a7f987d8e8bbac93676d56c7a7c3b77e200f81451206a6f7'
+$url = 'https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_windows_386.zip'
+$url64 = 'https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_windows_amd64.zip'
+$checksum = '98b10e598c7aa58eea4bdc6cd640a2cfa8870272b2d4e2dd20d595c55e68ee82'
+$checksum64 = '2970fbb5eddcabe85b546a88ffcfc34c5fa2881379dac637af5e08e577fc0bee'
 
 $unzipLocation = Split-Path -Parent $MyInvocation.MyCommand.Definition
 

--- a/terraform/update.ps1
+++ b/terraform/update.ps1
@@ -92,7 +92,8 @@ function Get-TerraformBuild($builds, $os, $arch) {
 function global:au_GetLatest {
   $terraformCheckpoint = Invoke-RestMethod -Uri $checkpointUrl
   Write-Verbose (ConvertTo-Json $terraformCheckpoint)
-  $currentDownloadUrl = $terraformCheckpoint.current_download_url
+  # remove trailing slash from current_download_url (if present)
+  $currentDownloadUrl = $terraformCheckpoint.current_download_url.Trim('/')
   $terraformBuilds = Invoke-RestMethod -Uri "$($currentDownloadUrl)/index.json"
   Write-Verbose (ConvertTo-Json $terraformBuilds)
   $shasums = Get-Shasums "$($currentDownloadUrl)/$($terraformBuilds.shasums)"


### PR DESCRIPTION
- Fix update.ps1 to handle when 'current_download_url' is returned with a trailing slash (as for some reason it is now)

JSON returned now from https://checkpoint-api.hashicorp.com/v1/check/terraform
![image](https://github.com/jamestoyer/chocolatey-packages/assets/384747/9d532478-fe24-4abf-bba1-9e7e75e94825)

Fixes #306